### PR TITLE
Add --headless argument for CLI-triggered database updates.

### DIFF
--- a/application.h
+++ b/application.h
@@ -40,7 +40,7 @@ class Application : public QApplication
     Q_DISABLE_COPY(Application)
 
 public:
-    Application(int& argc, char** argv);
+    Application(int& argc, char** argv, bool headless);
     ~Application();
 
 signals:
@@ -69,6 +69,10 @@ public:
 private:
     void startPlay(const QString& url) const;
     void startDownload(const QString& title, const QString& url) const;
+
+    void logStartedDatabaseUpdate();
+    void logCompletedDatabaseUpdate();
+    void logDatabaseUpdateFailure(const QString& error);
 
 private:
     Settings* m_settings;


### PR DESCRIPTION
This will not trigger a database unconditionally just as with the GUI, it will only give the update check and a possibly subsequent update a chance to run.

Closes #27 